### PR TITLE
Changes to replace PyWin32 for PyInstaller

### DIFF
--- a/pywintypes.py
+++ b/pywintypes.py
@@ -1,0 +1,1 @@
+from win32ctypes.pywin32.pywintypes import *

--- a/win32api.py
+++ b/win32api.py
@@ -1,0 +1,1 @@
+from win32ctypes.pywin32.win32api import *

--- a/win32ctypes/core/ctypes/_kernel32.py
+++ b/win32ctypes/core/ctypes/_kernel32.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 import ctypes
 from ctypes.wintypes import (
     BOOL, DWORD, HANDLE, HMODULE, LPCWSTR, WORD, HRSRC,
-    HGLOBAL, LPVOID, UINT)
+    HGLOBAL, LPVOID, UINT, LPWSTR, MAX_PATH)
 
 from ._common import LONG_PTR, IS_INTRESOURCE
 from ._util import check_null, check_zero, function_factory
@@ -123,6 +123,54 @@ _GetTickCount = function_factory(
     kernel32.GetTickCount,
     None,
     DWORD)
+
+_BeginUpdateResource = function_factory(
+    kernel32.BeginUpdateResourceW,
+    [LPCWSTR, BOOL],
+    HANDLE,
+    check_null)
+
+_EndUpdateResource = function_factory(
+    kernel32.EndUpdateResourceW,
+    [HANDLE, BOOL],
+    BOOL,
+    check_zero)
+
+_BaseUpdateResource = function_factory(
+    kernel32.UpdateResourceW,
+    [HANDLE, LPCWSTR, LPCWSTR, WORD, LPVOID, DWORD],
+    BOOL,
+    check_zero)
+
+_BaseGetWindowsDirectory = function_factory(
+    kernel32.GetWindowsDirectoryW,
+    [LPWSTR, UINT],
+    UINT,
+    check_zero)
+
+_BaseGetSystemDirectory = function_factory(
+    kernel32.GetSystemDirectoryW,
+    [LPWSTR, UINT],
+    UINT,
+    check_zero)
+
+
+def _GetWindowsDirectory():
+    buffer = ctypes.create_unicode_buffer(MAX_PATH)
+    _BaseGetWindowsDirectory(buffer, MAX_PATH)
+    return ctypes.cast(buffer, LPCWSTR).value
+
+
+def _GetSystemDirectory():
+    buffer = ctypes.create_unicode_buffer(MAX_PATH)
+    _BaseGetSystemDirectory(buffer, MAX_PATH)
+    return ctypes.cast(buffer, LPCWSTR).value
+
+
+def _UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, cbData):
+    lp_type = LPCWSTR(lpType)
+    lp_name = LPCWSTR(lpName)
+    return _BaseUpdateResource(hUpdate, lp_type, lp_name, wLanguage, lpData, cbData)
 
 
 def _EnumResourceNames(hModule, lpszType, lpEnumFunc, lParam):

--- a/win32ctypes/pywin32/win32api.py
+++ b/win32ctypes/pywin32/win32api.py
@@ -206,3 +206,28 @@ def FreeLibrary(hModule):
 
 def GetTickCount():
     return _kernel32._GetTickCount()
+
+
+def BeginUpdateResource(pFileName, bDeleteExistingResources):
+    with _pywin32error():
+        return _kernel32._BeginUpdateResource(pFileName, bDeleteExistingResources)
+
+
+def EndUpdateResource(hUpdate, fDiscard):
+    with _pywin32error():
+        return _kernel32._EndUpdateResource(hUpdate, fDiscard)
+
+
+def UpdateResource(hUpdate, lpType, lpName, lpData, wLanguage):
+    with _pywin32error():
+        return _kernel32._UpdateResource(hUpdate, lpType, lpName, wLanguage, lpData, len(lpData))
+
+
+def GetWindowsDirectory():
+    with _pywin32error():
+        return _kernel32._GetWindowsDirectory()
+
+
+def GetSystemDirectory():
+    with _pywin32error():
+        return _kernel32._GetSystemDirectory()


### PR DESCRIPTION
I've added some ctypes binding so that we can use pywin32-ctypes in place of pywin32 for PyInstaller. I didn't implement the CFFI portions of it since I'm not using it in my PC.